### PR TITLE
重构 InfluxDB Source/Sink 及适配 Flink 1.20，剥离 Telegraf，增强分片与配置能力

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ can be run using:
 ## 对于本fork的说明
 
 王旻安正在维护这个fork以使flink-connector-influxdb2的连接器继续可用，目前正在适配的版本为 flink 1.20.0 LTS 与 influxdb 2.7 OSS
+
+王旻安模仿 flink-connector-jdbc 重写了整个InfluxDBSource的逻辑以剥离Telegraf，现在InfluxDBSource会根据时间进行分片从指定的bucket-measurement中拉取数据
+
+王旻安模仿 flink-connector-jdbc 修正了InfluxDBSink的部分逻辑，添加了定时flush数据的功能

--- a/flink-connector-influxdb2/README.md
+++ b/flink-connector-influxdb2/README.md
@@ -44,12 +44,12 @@ This module is compatible with InfluxDB 2.x and InfluxDB 1.8+. See more informat
 
 满足标准的数据源Source语义，现在的InfluxDBSource从InfluxDB读取数据，而不是原先的CDC模式，如果您需要使用bahir原先版本的数据接入逻辑，请使用bahir标准仓库main分支。
 
-现在的InfluxDBSource通过influxdb-client-java读取数据
+现在的InfluxDBSource通过influxdb-client-java分片读取时序数据数据
 
 ```mermaid
-graph LR
-    InfluxDBDataBase[InfluxDB Database] --> InfluxDBSource[InfluxDB Source]
-    InfluxDBSource --> FlinkOperator((Flink Operator))
+flowchart LR
+    InfluxDBDataBase["InfluxDB Database"] -- influxdb-client-java --> InfluxDBSource["InfluxDB Source"]
+    InfluxDBSource -- POJO --> FlinkOperator(("Flink Operator"))
 ```
 
 您可以参考[InfluxDBSourceDemo.java](./src/test/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceDemo.java)中的用例查看具体用法

--- a/flink-connector-influxdb2/README.md
+++ b/flink-connector-influxdb2/README.md
@@ -42,6 +42,20 @@ This module is compatible with InfluxDB 2.x and InfluxDB 1.8+. See more informat
 
 ## Source
 
+满足标准的数据源Source语义，现在的InfluxDBSource从InfluxDB读取数据，而不是原先的CDC模式，如果您需要使用bahir原先版本的数据接入逻辑，请使用bahir标准仓库main分支。
+
+现在的InfluxDBSource通过influxdb-client-java读取数据
+
+```mermaid
+graph LR
+    InfluxDBDataBase[InfluxDB Database] --> InfluxDBSource[InfluxDB Source]
+    InfluxDBSource --> FlinkOperator((Flink Operator))
+```
+
+您可以参考[InfluxDBSourceDemo.java](./src/test/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceDemo.java)中的用例查看具体用法
+
+## Source(Bahir Former Version)
+
 The Source accepts data in the form of the [Line Protocol](https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/). One HTTP server per source instance is started. It parses HTTP requests to our Data Point class. That Data Point instance is deserialized by a user-provided implementation of our InfluxDBDataPointDeserializer and sent to the next Flink operator.
 
 When using Telegraf, use its [HTTP output plugin](https://docs.influxdata.com/telegraf/v1.17/plugins/#http):

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/common/DataPoint.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/common/DataPoint.java
@@ -51,7 +51,7 @@ public final class DataPoint {
     private final Map<String, Object> fields = new HashMap<>();
     private final Long timestamp;
 
-    DataPoint(final String measurementName, @Nullable final Long timestamp) {
+    public DataPoint(final String measurementName, @Nullable final Long timestamp) {
         Arguments.checkNotNull(measurementName, "measurement");
         this.measurement = measurementName;
         this.timestamp = timestamp;
@@ -158,5 +158,15 @@ public final class DataPoint {
     @Override
     public int hashCode() {
         return Objects.hash(this.measurement, this.fields, this.timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "DataPoint{" +
+                "measurement='" + measurement + '\'' +
+                ", tags=" + tags +
+                ", fields=" + fields +
+                ", timestamp=" + timestamp +
+                '}';
     }
 }

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/common/InfluxParser.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/common/InfluxParser.java
@@ -35,10 +35,10 @@ import java.util.regex.Pattern;
  * This is an InfluxDB line protocol parser.
  *
  * @see <a href=https://docs.influxdata.com/influxdb/v2.0/reference/syntax/line-protocol/">Line
- *     Protocol</a>
+ * Protocol</a>
  * This class contains code copied from the <a
- *     href=https://github.com/apache/druid/blob/master/extensions-contrib/influx-extensions/src/main/java/org/apache/druid/data/input/influx/InfluxParser.java>
- *     Apache Druid InfluxDB Parser </a>, licensed under the Apache License, Version 2.0.
+ * href=https://github.com/apache/druid/blob/master/extensions-contrib/influx-extensions/src/main/java/org/apache/druid/data/input/influx/InfluxParser.java>
+ * Apache Druid InfluxDB Parser </a>, licensed under the Apache License, Version 2.0.
  */
 @Internal
 public final class InfluxParser {
@@ -62,7 +62,7 @@ public final class InfluxParser {
                     "Multiple lines present; unable to parse more than one per record.", 0);
         }
 
-        final InfluxLineProtocolParser.LineContext line = lines.get(0);
+        final InfluxLineProtocolParser.LineContext line = lines.getFirst();
         final String measurement = parseIdentifier(line.identifier());
 
         final Long timestamp = parseTimestamp(line.timestamp());

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/sink/InfluxDBSinkBuilder.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/sink/InfluxDBSinkBuilder.java
@@ -21,7 +21,14 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.connectors.influxdb.sink.writer.InfluxDBSchemaSerializer;
 import org.apache.flink.streaming.connectors.influxdb.sink.writer.InfluxDBWriter;
 
-import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.*;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.INFLUXDB_BUCKET;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.INFLUXDB_ORGANIZATION;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.INFLUXDB_PASSWORD;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.INFLUXDB_TOKEN;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.INFLUXDB_URL;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.INFLUXDB_USERNAME;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.WRITE_BUFFER_SIZE;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.WRITE_DATA_POINT_CHECKPOINT;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/sink/writer/InfluxDBWriter.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/sink/writer/InfluxDBWriter.java
@@ -32,7 +32,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.*;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.WRITE_BUFFER_SIZE;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.WRITE_DATA_POINT_CHECKPOINT;
+import static org.apache.flink.streaming.connectors.influxdb.sink.InfluxDBSinkOptions.getInfluxDBClient;
 
 /**
  * This Class implements the {@link SinkWriter} and it is responsible to write incoming inputs to

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/sink2/InfluxDBSinkBuilder.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/sink2/InfluxDBSinkBuilder.java
@@ -21,7 +21,15 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.connectors.influxdb.sink2.writer.InfluxDBSchemaSerializer;
 import org.apache.flink.streaming.connectors.influxdb.sink2.writer.InfluxDBWriter;
 
-import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.*;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.BATCH_INTERVAL_MS;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.INFLUXDB_BUCKET;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.INFLUXDB_ORGANIZATION;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.INFLUXDB_PASSWORD;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.INFLUXDB_TOKEN;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.INFLUXDB_URL;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.INFLUXDB_USERNAME;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.WRITE_BUFFER_SIZE;
+import static org.apache.flink.streaming.connectors.influxdb.sink2.InfluxDBSinkOptions.WRITE_DATA_POINT_CHECKPOINT;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceBuilder.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceBuilder.java
@@ -80,22 +80,26 @@ public final class InfluxDBSourceBuilder<OUT> {
 
     public InfluxDBSourceBuilder<OUT> setStartTime(final long startTime) {
         this.startTime = startTime;
+        this.configuration.set(InfluxDBSourceOptions.START_TIME, checkNotNull(startTime));
         return this;
     }
 
     public InfluxDBSourceBuilder<OUT> setEndTime(final long endTime) {
         this.stopTime = endTime;
+        this.configuration.set(InfluxDBSourceOptions.END_TIME, checkNotNull(endTime));
         return this;
     }
 
     public InfluxDBSourceBuilder<OUT> setSplitDuration(final long splitDuration) {
         this.splitDuration = splitDuration;
+        this.configuration.set(InfluxDBSourceOptions.SPLIT_DURATION, checkNotNull(splitDuration));
         return this;
     }
 
 
     public InfluxDBSourceBuilder<OUT> setMeasurementName(final String measurementName) {
         this.measurementName = measurementName;
+        this.configuration.set(InfluxDBSourceOptions.MEASUREMENT_NAME, checkNotNull(measurementName));
         return this;
     }
 

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceOptions.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceOptions.java
@@ -27,8 +27,35 @@ import org.apache.flink.configuration.Configuration;
 /* Configurations for a InfluxDBSource. */
 public final class InfluxDBSourceOptions {
 
-    private InfluxDBSourceOptions() {}
+    private InfluxDBSourceOptions() {
+    }
 
+    // 查询和读取相关配置
+    public static final ConfigOption<String> MEASUREMENT_NAME =
+            ConfigOptions.key("source.influxDB.measurement")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("InfluxDB measurement name to query from.");
+
+    public static final ConfigOption<Long> START_TIME =
+            ConfigOptions.key("source.influxDB.query.startTime")
+                    .longType()
+                    .defaultValue(0L)
+                    .withDescription("Start time for the query in nanoseconds since epoch.");
+
+    public static final ConfigOption<Long> END_TIME =
+            ConfigOptions.key("source.influxDB.query.endTime")
+                    .longType()
+                    .defaultValue(Long.MAX_VALUE)
+                    .withDescription("End time for the query in nanoseconds since epoch.");
+
+    public static final ConfigOption<Long> SPLIT_DURATION =
+            ConfigOptions.key("source.influxDB.split.duration")
+                    .longType()
+                    .defaultValue(60 * 60 * 1_000_000_000L)  // 默认1小时（纳秒）
+                    .withDescription("Duration of each split in nanoseconds.");
+
+    // 队列和性能相关配置
     public static final ConfigOption<Long> ENQUEUE_WAIT_TIME =
             ConfigOptions.key("source.influxDB.timeout.enqueue")
                     .longType()
@@ -43,38 +70,39 @@ public final class InfluxDBSourceOptions {
                     .withDescription(
                             "Size of queue that buffers HTTP requests data points before fetching.");
 
+    // 客户��连接相关配置 - 修正前缀为source.influxDB
     public static final ConfigOption<String> INFLUXDB_URL =
-            ConfigOptions.key("sink.influxDB.client.URL")
+            ConfigOptions.key("source.influxDB.client.URL")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("InfluxDB Connection URL.");
 
     public static final ConfigOption<String> INFLUXDB_USERNAME =
-            ConfigOptions.key("sink.influxDB.client.username")
+            ConfigOptions.key("source.influxDB.client.username")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("InfluxDB username.");
 
     public static final ConfigOption<String> INFLUXDB_PASSWORD =
-            ConfigOptions.key("sink.influxDB.client.password")
+            ConfigOptions.key("source.influxDB.client.password")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("InfluxDB password.");
 
     public static final ConfigOption<String> INFLUXDB_TOKEN =
-            ConfigOptions.key("sink.influxDB.client.token")
+            ConfigOptions.key("source.influxDB.client.token")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("InfluxDB access token.");
 
     public static final ConfigOption<String> INFLUXDB_BUCKET =
-            ConfigOptions.key("sink.influxDB.client.bucket")
+            ConfigOptions.key("source.influxDB.client.bucket")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("InfluxDB bucket name.");
 
     public static final ConfigOption<String> INFLUXDB_ORGANIZATION =
-            ConfigOptions.key("sink.influxDB.client.organization")
+            ConfigOptions.key("source.influxDB.client.organization")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("InfluxDB organization name.");

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/enumerator/InfluxDBSplitEnumerator.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/enumerator/InfluxDBSplitEnumerator.java
@@ -17,50 +17,205 @@
  */
 package org.apache.flink.streaming.connectors.influxdb.source.enumerator;
 
-import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.streaming.connectors.influxdb.source.split.InfluxDBSplit;
 import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-/** The enumerator class for InfluxDB source. */
-@Internal
-public final class InfluxDBSplitEnumerator
-        implements SplitEnumerator<InfluxDBSplit, InfluxDBSourceEnumState> {
+/**
+ * The enumerator class for InfluxDB source.
+ */
+public class InfluxDBSplitEnumerator implements SplitEnumerator<InfluxDBSplit, InfluxDBSourceEnumState> {
+    private static final Logger LOG = LoggerFactory.getLogger(InfluxDBSplitEnumerator.class);
 
     private final SplitEnumeratorContext<InfluxDBSplit> context;
+    private final String bucket;
+    private final String measurement;
+    private final long startTime;
+    private final long endTime;
+    private final long splitDuration;
+    private final Boundedness boundedness;
 
-    public InfluxDBSplitEnumerator(final SplitEnumeratorContext<InfluxDBSplit> context) {
+    // 存储未分配的splits
+    private final List<InfluxDBSplit> unassignedSplits = new ArrayList<>();
+    // 等待分配split的读取器
+    private final Map<Integer, String> readersAwaitingSplit = new HashMap<>();
+
+    public InfluxDBSplitEnumerator(
+            SplitEnumeratorContext<InfluxDBSplit> context,
+            String bucket,
+            String measurement,
+            long startTime,
+            long endTime,
+            long splitDuration,
+            Boundedness boundedness) {
         this.context = checkNotNull(context);
+        this.bucket = checkNotNull(bucket);
+        this.measurement = measurement;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.splitDuration = splitDuration;
+        this.boundedness = boundedness;
+    }
+
+    public InfluxDBSplitEnumerator(
+            SplitEnumeratorContext<InfluxDBSplit> context,
+            String bucket,
+            String measurement,
+            long startTime,
+            long endTime,
+            long splitDuration,
+            Boundedness boundedness,
+            List<InfluxDBSplit> unassignedSplits) {
+        this(context, bucket, measurement, startTime, endTime, splitDuration, boundedness);
+        this.unassignedSplits.addAll(unassignedSplits);
     }
 
     @Override
     public void start() {
-        // no resources to start
+        // 为有界流一次性创建所有分片
+        if (boundedness == Boundedness.BOUNDED) {
+            createTimeBasedSplits();
+        } else {
+            // 对于无界流，定期创建新的分片
+            long currentTimeMillis = System.currentTimeMillis();
+            // 创建过去时间范围的分片
+            createSplitsForTimeRange(startTime, Math.min(endTime, currentTimeMillis));
+
+            // 定期创建新的分片（对于实时数据）
+            context.callAsync(
+                    this::discoverNewSplits,
+                    this::processNewSplits,
+                    60000, // 每分钟检查一次新数据
+                    30000); // 初始延迟30秒
+        }
+    }
+
+    private List<InfluxDBSplit> discoverNewSplits() {
+        long currentTimeMillis = System.currentTimeMillis();
+        List<InfluxDBSplit> newSplits = new ArrayList<>();
+
+        // 获取上次处理的最新时间
+        long lastProcessedTime = unassignedSplits.isEmpty() ?
+                startTime :
+                unassignedSplits.stream()
+                        .mapToLong(InfluxDBSplit::getEndTime)
+                        .max()
+                        .orElse(startTime);
+
+        // 只为新的时间范围创建分片
+        if (lastProcessedTime < currentTimeMillis) {
+            long nextEndTime = Math.min(endTime, currentTimeMillis);
+            newSplits.addAll(createSplitsForTimeRange(lastProcessedTime, nextEndTime));
+        }
+
+        return newSplits;
+    }
+
+    private void processNewSplits(List<InfluxDBSplit> newSplits, Throwable error) {
+        if (error != null) {
+            LOG.error("Failed to discover new splits", error);
+            return;
+        }
+
+        if (!newSplits.isEmpty()) {
+            LOG.info("Discovered {} new splits", newSplits.size());
+            unassignedSplits.addAll(newSplits);
+            assignSplits();
+        }
+    }
+
+    private void createTimeBasedSplits() {
+        unassignedSplits.addAll(createSplitsForTimeRange(startTime, endTime));
+    }
+
+    private List<InfluxDBSplit> createSplitsForTimeRange(long rangeStart, long rangeEnd) {
+        List<InfluxDBSplit> splits = new ArrayList<>();
+
+        // 根据splitDuration将时间范围分割成多个小区间
+        for (long start = rangeStart; start < rangeEnd; start += splitDuration) {
+            long end = Math.min(start + splitDuration, rangeEnd);
+            String splitId = measurement + "-" + start + "-" + end;
+            InfluxDBSplit influxDBSplit = new InfluxDBSplit(splitId, bucket, measurement, start, end);
+            influxDBSplit.setStartTime(start);
+            influxDBSplit.setEndTime(end);
+            influxDBSplit.setSplitDuration(splitDuration);
+            splits.add(influxDBSplit);
+        }
+
+        LOG.info("Created {} splits for time range [{}, {}]",
+                splits.size(), rangeStart, rangeEnd);
+        return splits;
     }
 
     @Override
-    public void handleSplitRequest(final int subtaskId, @Nullable final String requesterHostname) {
-        this.context.assignSplit(new InfluxDBSplit(subtaskId), subtaskId);
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        if (unassignedSplits.isEmpty()) {
+            if (boundedness == Boundedness.BOUNDED &&
+                readersAwaitingSplit.isEmpty() &&
+                context.registeredReaders().containsKey(subtaskId)) {
+                // 有界流且没有更多分片，发送完成信号
+                context.signalNoMoreSplits(subtaskId);
+                LOG.info("No more splits available for subtask {}, signaling completion", subtaskId);
+            } else {
+                // 添加到等待列表
+                readersAwaitingSplit.put(subtaskId, requesterHostname);
+                LOG.info("No splits available for subtask {}, adding to waiting list", subtaskId);
+            }
+        } else {
+            // 分配一个分片
+            InfluxDBSplit split = unassignedSplits.removeFirst();
+            context.assignSplit(split, subtaskId);
+            LOG.info("Assigned split {} to subtask {}", split, subtaskId);
+        }
+    }
+
+    private void assignSplits() {
+        // 为等待的读取器分配分片
+        Iterator<Map.Entry<Integer, String>> iterator = readersAwaitingSplit.entrySet().iterator();
+        while (iterator.hasNext() && !unassignedSplits.isEmpty()) {
+            Map.Entry<Integer, String> entry = iterator.next();
+            InfluxDBSplit split = unassignedSplits.removeFirst();
+            context.assignSplit(split, entry.getKey());
+            iterator.remove();
+            LOG.info("Assigned split {} to waiting subtask {}", split, entry.getKey());
+        }
     }
 
     @Override
-    public void addSplitsBack(final List<InfluxDBSplit> splits, final int subtaskId) {}
+    public void addSplitsBack(List<InfluxDBSplit> splits, int subtaskId) {
+        LOG.info("Adding back {} splits from subtask {}", splits.size(), subtaskId);
+        unassignedSplits.addAll(splits);
 
-    @Override
-    public void addReader(final int subtaskId) {
-        // this source is purely lazy-pull-based, nothing to do upon registration
+        // 如果当前有读取器在等待分片，尝试重新分配
+        if (!readersAwaitingSplit.isEmpty()) {
+            assignSplits();
+        }
     }
 
     @Override
-    public InfluxDBSourceEnumState snapshotState(long l) throws Exception {
-        return new InfluxDBSourceEnumState();
+    public InfluxDBSourceEnumState snapshotState(long checkpointId) {
+        return new InfluxDBSourceEnumState(new ArrayList<>(unassignedSplits));
     }
 
     @Override
-    public void close() {}
+    public void addReader(int subtaskId) {
+        // 读取器注册时不需要特殊处理
+    }
+
+    @Override
+    public void close() {
+        // 没有需要关闭的资源
+    }
 }

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/reader/InfluxDBSplitReader.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/reader/InfluxDBSplitReader.java
@@ -1,7 +1,7 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
+ * distributed with this work for additional debugrmation
  * regarding copyright ownership. The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
@@ -17,25 +17,33 @@
  */
 package org.apache.flink.streaming.connectors.influxdb.source.reader;
 
-import com.sun.net.httpserver.HttpServer;
+import com.influxdb.client.InfluxDBClient;
+import com.influxdb.client.InfluxQLQueryApi;
+import com.influxdb.client.domain.InfluxQLQuery;
+import com.influxdb.query.InfluxQLQueryResult;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsBySplits;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.streaming.connectors.influxdb.common.DataPoint;
-import org.apache.flink.streaming.connectors.influxdb.source.http.HealthCheckHandler;
-import org.apache.flink.streaming.connectors.influxdb.source.http.WriteAPIHandler;
+import org.apache.flink.streaming.connectors.influxdb.source.reader.deserializer.DataPointQueryResultDeserializer;
 import org.apache.flink.streaming.connectors.influxdb.source.split.InfluxDBSplit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.util.*;
-import java.util.concurrent.ExecutionException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
 
-import static org.apache.flink.streaming.connectors.influxdb.source.InfluxDBSourceOptions.*;
+import static org.apache.flink.streaming.connectors.influxdb.source.InfluxDBSourceOptions.INGEST_QUEUE_CAPACITY;
+import static org.apache.flink.streaming.connectors.influxdb.source.InfluxDBSourceOptions.getInfluxDBClient;
 
 /**
  * A {@link SplitReader} implementation that reads records from InfluxDB splits.
@@ -45,44 +53,99 @@ import static org.apache.flink.streaming.connectors.influxdb.source.InfluxDBSour
 @Internal
 public final class InfluxDBSplitReader implements SplitReader<DataPoint, InfluxDBSplit> {
 
-    private final long enqueueWaitTime;
-    private final int maximumLinesPerRequest;
-    private final int defaultPort;
+    private static final Logger LOG = LoggerFactory.getLogger(InfluxDBSplitReader.class);
 
-    private HttpServer server = null;
+    private final InfluxDBClient influxDBClient;
+    private final List<String> whereCondition; // 基础查询模板
+    private final DataPointQueryResultDeserializer queryResultDeserializer;
+    private int emptyQueryCount = 0;
+    private static final int MAX_EMPTY_QUERY_ATTEMPTS = 3;
+
 
     private final FutureCompletingBlockingQueue<List<DataPoint>> ingestionQueue;
-
     private InfluxDBSplit split;
 
-    public InfluxDBSplitReader(final Configuration configuration) {
-        this.enqueueWaitTime = configuration.getLong(ENQUEUE_WAIT_TIME);
-        this.maximumLinesPerRequest = configuration.getInteger(MAXIMUM_LINES_PER_REQUEST);
-        this.defaultPort = configuration.getInteger(PORT);
-        final int capacity = configuration.getInteger(INGEST_QUEUE_CAPACITY);
+    public InfluxDBSplitReader(final Configuration configuration, List<String> whereCondition,
+                               DataPointQueryResultDeserializer queryResultDeserializer) {
+        final int capacity = configuration.get(INGEST_QUEUE_CAPACITY);
         this.ingestionQueue = new FutureCompletingBlockingQueue<>(capacity);
+        this.influxDBClient = getInfluxDBClient(configuration);
+        this.whereCondition = whereCondition;
+        this.queryResultDeserializer = queryResultDeserializer;
     }
 
     @Override
     public RecordsWithSplitIds<DataPoint> fetch() throws IOException {
         if (this.split == null) {
-            return null;
+            return new RecordsBySplits.Builder<DataPoint>().build();
         }
-        final InfluxDBSplitRecords recordsBySplits = new InfluxDBSplitRecords(this.split.splitId());
 
-        try {
-            this.ingestionQueue.getAvailabilityFuture().get();
-        } catch (final InterruptedException | ExecutionException exception) {
-            throw new IOException("An exception occurred during fetch", exception);
+        final RecordsBySplits.Builder<DataPoint> builder = new RecordsBySplits.Builder<>();
+
+        // 检查是否已处理完当前分片
+        if (split.getCurrentOffset() >= split.getEndTime()) {
+            return finishSplit();
         }
-        final List<DataPoint> requests = this.ingestionQueue.poll();
-        if (requests == null) {
-            recordsBySplits.prepareForRead();
-            return recordsBySplits;
+
+        // 尝试从队列中获取数据点
+        List<DataPoint> dataPoints = this.ingestionQueue.poll();
+
+        if (dataPoints == null || dataPoints.isEmpty()) {
+            // 如果队列为空且当前分片未处理完，执行查询
+            if (split.getCurrentOffset() < split.getEndTime()) {
+                executeQueryForSplit();
+                dataPoints = this.ingestionQueue.poll();
+            }
+
+            // 执行查询后仍无数据，可能是该时间范围内没有数据
+            if (dataPoints == null || dataPoints.isEmpty()) {
+                emptyQueryCount++;
+                if (emptyQueryCount >= MAX_EMPTY_QUERY_ATTEMPTS) {
+                    // 连续多次查询无数据，认为分片已处理完毕
+                    LOG.debug("No more data in split {} after {} attempts", split.splitId(), MAX_EMPTY_QUERY_ATTEMPTS);
+                    return finishSplit();
+                }
+                // 移动时间窗口继续查询
+                long nextOffset = split.getCurrentOffset() + split.getSplitDuration() / MAX_EMPTY_QUERY_ATTEMPTS;
+                nextOffset = Math.min(nextOffset, split.getEndTime());
+                split.setCurrentOffset(nextOffset);
+                return builder.build();
+            }
         }
-        recordsBySplits.addAll(requests);
-        recordsBySplits.prepareForRead();
-        return recordsBySplits;
+
+        // 重置空查询计数器
+        emptyQueryCount = 0;
+
+        // 添加记录到结果
+        for (DataPoint dataPoint : dataPoints) {
+            builder.add(split.splitId(), dataPoint);
+        }
+
+        // 更新当前处理的偏移量为最后一个数据点的时间戳+1（确保下次不重复查询）
+        long lastTimestamp = dataPoints.stream()
+                .mapToLong(DataPoint::getTimestamp)
+                .max()
+                .orElse(split.getCurrentOffset());
+
+        // 确保偏移量至少前进一点，避免原地踏步
+        split.setCurrentOffset(Math.max(lastTimestamp + 1, split.getCurrentOffset() + 1));
+
+        // 检查是否处理完毕
+        if (split.getCurrentOffset() >= split.getEndTime()) {
+            builder.addFinishedSplit(split.splitId());
+        }
+
+        return builder.build();
+    }
+
+    private RecordsWithSplitIds<DataPoint> finishSplit() {
+        RecordsBySplits.Builder<DataPoint> builder = new RecordsBySplits.Builder<>();
+        builder.addFinishedSplit(split.splitId());
+        LOG.debug("Finished processing split: {}", split.splitId());
+        // 清除当前分片引用
+        split = null;
+        emptyQueryCount = 0;
+        return builder.build();
     }
 
     @Override
@@ -90,30 +153,58 @@ public final class InfluxDBSplitReader implements SplitReader<DataPoint, InfluxD
         if (splitsChange.splits().isEmpty()) {
             return;
         }
-        this.split = splitsChange.splits().get(0);
 
-        if (this.server != null) {
-            return;
+        // 停止处理当前分片
+        if (this.split != null) {
+            LOG.debug("Switching from split {} to new split", this.split.splitId());
         }
+
+        this.split = splitsChange.splits().getFirst();
+        LOG.debug("Received new split: {}", this.split);
+
+        // 执行新分片的查询
+        executeQueryForSplit();
+    }
+
+    private void executeQueryForSplit() {
+        // 为当前分片构建InfluxQL查询
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("SELECT * FROM ")
+                .append(split.getMeasurement())
+                .append(" WHERE time >= ")
+                .append(split.getCurrentOffset())
+                .append(" AND time < ")  // 注意添加时间单位us
+                .append(Math.min(split.getCurrentOffset() + split.getSplitDuration(), split.getEndTime()));
+
+        // 添加where条件
+        if (whereCondition != null && !whereCondition.isEmpty()) {
+            queryBuilder
+                    .append(" AND ")
+                    .append(String.join(" AND ", whereCondition));
+        }
+
+        // 按时间排序确保结果有序
+        queryBuilder.append(" ORDER BY time ASC");
+
+        InfluxQLQueryApi queryApi = influxDBClient.getInfluxQLQueryApi();
+        LOG.debug("Executing query: {}", queryBuilder);
+        InfluxQLQuery influxQLQuery = new InfluxQLQuery(queryBuilder.toString(), split.getBucket());
+
         try {
-            this.server = HttpServer.create(new InetSocketAddress(this.defaultPort), 0);
-        } catch (final IOException e) {
-            throw new RuntimeException(
-                    String.format(
-                            "Unable to start HTTP Server on Port %d: %s",
-                            this.defaultPort, e.getMessage()));
+            InfluxQLQueryResult queryResult = queryApi.query(influxQLQuery.setAcceptHeader(InfluxQLQuery.AcceptHeader.CSV));
+            List<DataPoint> dataPoints = queryResultDeserializer.deserialize(queryResult);
+            LOG.debug("Query returned {} data points", dataPoints.size());
+            this.ingestionQueue.put(split.splitId().hashCode(), dataPoints);
+        } catch (Exception e) {
+            LOG.error("Error executing query: {}", e.getMessage(), e);
+            // 放入空列表避免阻塞
+            try {
+                this.ingestionQueue.put(split.splitId().hashCode(), Collections.emptyList());
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+                LOG.error("Interrupted while putting empty list to queue", ie);
+            }
         }
-
-        this.server.createContext(
-                "/api/v2/write",
-                new WriteAPIHandler(
-                        this.maximumLinesPerRequest,
-                        this.ingestionQueue,
-                        this.split.splitId().hashCode(),
-                        this.enqueueWaitTime));
-        this.server.createContext("/health", new HealthCheckHandler());
-        this.server.setExecutor(null); // creates a default executor
-        this.server.start();
     }
 
     @Override
@@ -123,8 +214,12 @@ public final class InfluxDBSplitReader implements SplitReader<DataPoint, InfluxD
 
     @Override
     public void close() {
-        if (this.server != null) {
-            this.server.stop(1); // waits max 1 second for pending requests to finish
+        if (this.influxDBClient != null) {
+            try {
+                this.influxDBClient.close();
+            } catch (final Exception e) {
+                throw new RuntimeException("Failed to close InfluxDB client", e);
+            }
         }
     }
 

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/reader/deserializer/DataPointQueryResultDeserializer.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/reader/deserializer/DataPointQueryResultDeserializer.java
@@ -15,30 +15,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.flink.streaming.connectors.influxdb.source.enumerator;
+package org.apache.flink.streaming.connectors.influxdb.source.reader.deserializer;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.streaming.connectors.influxdb.source.split.InfluxDBSplit;
+import com.influxdb.query.InfluxQLQueryResult;
+import org.apache.flink.streaming.connectors.influxdb.common.DataPoint;
 
-import java.util.ArrayList;
+import java.io.Serializable;
 import java.util.List;
 
-/**
- * The state of InfluxDB source enumerator.
- */
-@Internal
-public class InfluxDBSourceEnumState {
-    private final List<InfluxDBSplit> unassignedSplits;
+/** An interface for the deserialization of InfluxDB data points. */
+public interface DataPointQueryResultDeserializer extends Serializable {
 
-    public InfluxDBSourceEnumState() {
-        this.unassignedSplits = new ArrayList<>();
-    }
-
-    public InfluxDBSourceEnumState(List<InfluxDBSplit> unassignedSplits) {
-        this.unassignedSplits = unassignedSplits;
-    }
-
-    public List<InfluxDBSplit> getUnassignedSplits() {
-        return unassignedSplits;
-    }
+    List<DataPoint> deserialize(InfluxQLQueryResult queryResult);
 }

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/split/InfluxDBSplit.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/split/InfluxDBSplit.java
@@ -1,42 +1,90 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.apache.flink.streaming.connectors.influxdb.source.split;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceSplit;
 
+import java.io.Serial;
+import java.io.Serializable;
+
 /** A {@link SourceSplit} for a InfluxDB split. */
 @Internal
-public final class InfluxDBSplit implements SourceSplit {
+public final class InfluxDBSplit implements SourceSplit, Serializable {
 
-    /** The unique ID of the split. Unique within the scope of this source. */
-    private final long id;
+    @Serial
+    private static final long serialVersionUID = 1L;
 
-    public InfluxDBSplit(final long id) {
-        this.id = id;
+    private final String splitId;
+    private final String bucket;
+    private final String measurement;  // 测量名称
+    private long startTime;      // 查询开始时间戳(us)
+    private long endTime;        // 查询结束时间戳(us)
+    private long splitDuration;  // 分片数据量大小
+    private long currentOffset;  // 当前处理的时间戳偏移量
+
+    public InfluxDBSplit(String splitId, String bucket, String measurement, long startTime, long endTime) {
+        this.splitId = splitId;
+        this.bucket = bucket;
+        this.measurement = measurement;
+        this.startTime = startTime;
+        this.endTime = endTime;
     }
 
+    // getter和setter方法
     @Override
     public String splitId() {
-        return String.valueOf(this.id);
+        return splitId;
     }
 
-    public long getId() {
-        return this.id;
+    public String getBucket() {
+        return bucket;
+    }
+
+    public String getMeasurement() {
+        return measurement;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(long startTime) {
+        this.startTime = startTime;
+    }
+
+    public long getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(long endTime) {
+        this.endTime = endTime;
+    }
+    public long getSplitDuration() {
+        return splitDuration;
+    }
+
+    public void setSplitDuration(long splitDuration) {
+        this.splitDuration = splitDuration;
+    }
+
+    public long getCurrentOffset() {
+        return currentOffset == 0 ? startTime : currentOffset;
+    }
+
+    public void setCurrentOffset(long currentOffset) {
+        this.currentOffset = currentOffset;
+    }
+
+    // 序列化支持
+    @Override
+    public String toString() {
+        return "InfluxDBSplit{" +
+                "splitId='" + splitId + '\'' +
+                ", bucket='" + bucket + '\'' +
+                ", measurement='" + measurement + '\'' +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                ", splitDuration=" + splitDuration +
+                ", currentOffset=" + currentOffset +
+                '}';
     }
 }

--- a/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/split/InfluxDBSplitSerializer.java
+++ b/flink-connector-influxdb2/src/main/java/org/apache/flink/streaming/connectors/influxdb/source/split/InfluxDBSplitSerializer.java
@@ -1,30 +1,16 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements. See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.apache.flink.streaming.connectors.influxdb.source.split;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
-import java.nio.ByteBuffer;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
 
 /**
- * The {@link org.apache.flink.core.io.SimpleVersionedSerializer serializer} for {@link
- * InfluxDBSplit}.
+ * InfluxDBSplit的序列化器实现。
  */
 @Internal
 public final class InfluxDBSplitSerializer implements SimpleVersionedSerializer<InfluxDBSplit> {
@@ -37,15 +23,44 @@ public final class InfluxDBSplitSerializer implements SimpleVersionedSerializer<
     }
 
     @Override
-    public byte[] serialize(final InfluxDBSplit influxDBSplit) {
-        final ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
-        buffer.putLong(0, influxDBSplit.getId());
-        return buffer.array();
+    public byte[] serialize(final InfluxDBSplit split) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             DataOutputStream out = new DataOutputStream(baos)) {
+
+            // 写入所有字段
+            out.writeUTF(split.splitId());
+            out.writeUTF(split.getBucket());
+            out.writeUTF(split.getMeasurement());
+            out.writeLong(split.getStartTime());
+            out.writeLong(split.getEndTime());
+            out.writeLong(split.getSplitDuration());
+
+            out.flush();
+            return baos.toByteArray();
+        }
     }
 
     @Override
-    public InfluxDBSplit deserialize(final int version, final byte[] serialized) {
-        final ByteBuffer buffer = ByteBuffer.wrap(serialized);
-        return new InfluxDBSplit(buffer.getLong());
+    public InfluxDBSplit deserialize(final int version, final byte[] serialized) throws IOException {
+        if (version != CURRENT_VERSION) {
+            throw new IOException("Unsupported version: " + version);
+        }
+
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+             DataInputStream in = new DataInputStream(bais)) {
+
+            // 读取所有字段
+            String splitId = in.readUTF();
+            String bucket = in.readUTF();
+            String measurement = in.readUTF();
+            long startTime = in.readLong();
+            long endTime = in.readLong();
+            long splitDuration = in.readLong();
+
+            // 创建并返回InfluxDBSplit实例
+            InfluxDBSplit split = new InfluxDBSplit(splitId, bucket, measurement, startTime, endTime);
+            split.setSplitDuration(splitDuration);
+            return split;
+        }
     }
 }

--- a/flink-connector-influxdb2/src/test/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceDemo.java
+++ b/flink-connector-influxdb2/src/test/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceDemo.java
@@ -1,0 +1,102 @@
+package org.apache.flink.streaming.connectors.influxdb.source;
+
+import com.influxdb.query.InfluxQLQueryResult;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.connectors.influxdb.common.DataPoint;
+import org.apache.flink.streaming.connectors.influxdb.source.reader.deserializer.DataPointQueryResultDeserializer;
+import org.apache.flink.streaming.connectors.influxdb.source.reader.deserializer.InfluxDBDataPointDeserializer;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * @author : [wangminan]
+ * @description : [一句话描述该类的功能]
+ */
+public class InfluxDBSourceDemo {
+
+    // LOG
+    private static final org.slf4j.Logger log = org.slf4j.LoggerFactory.getLogger(InfluxDBSourceDemo.class);
+
+    public static void main(String[] args) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(8);
+
+        InfluxDBSource<String> influxDBSource = InfluxDBSource.builder()
+                .setInfluxDBUrl("http://10.168.3.103:8086") // http://localhost:8086
+                .setInfluxDBToken("MgRgyNCKNoUiVtyylbHVhe0NwemLnHmSgO9HZ7dyZ6NUUU4c9oBkxGN9_wW_75GYN0YObGcYkAF1T2SnElko5Q==")
+                .setInfluxDBOrganization("lab418")  // influxdata
+                .setInfluxDBBucket("simulation")
+                // 内部队列参数 可以不设定用默认值
+                .setEnqueueWaitTime(5)
+                .setIngestQueueCapacity(10000)
+                .setMeasurementName("aa_traj")
+                // influxdb连接器的逻辑是基于时间片下发数据 因此您需要指定开始时间 结束时间以及一个分片的时间大小 精度都为纳秒
+                .setStartTime(convertInstantToNs(Instant.parse("2025-06-24T00:00:00Z")))
+                .setEndTime(convertInstantToNs(Instant.parse("2025-06-25T00:00:00Z")))
+                .setSplitDuration(10 * 60 * 1_000_000_000L) // 10MIN 一个shard
+                /*
+                    您的附加搜索条件 连接器会将其拼接到 WHERE 部分并通过 AND 连接 可以置空
+                    这是一个害怕分片内数据过多的不优雅的预留 我们建议您使用数据流本身的 map 和 filter 方法
+                 */
+                .setWhereCondition(List.of())
+                // 设置 influxdb query 返回值的解析器 在连接器框架下 该解析器将数据转换为 datapoint 响应对象
+                .setQueryResultDeserializer(
+                        (DataPointQueryResultDeserializer) queryResult -> {
+                            List<DataPoint> dataPoints = new ArrayList<>();
+                            for (InfluxQLQueryResult.Result resultResult : queryResult.getResults()) {
+                                for (InfluxQLQueryResult.Series series : resultResult.getSeries()) {
+                                    for (InfluxQLQueryResult.Series.Record record : series.getValues()) {
+                                        // 类似于 CSV 的列映射 在最深层的 for 循环中您需要指定字段与列的映射关系 在复用较多的场景下您将for循环中的内容单独提出一个方法
+                                        DataPoint dataPoint = new DataPoint("aa_traj",
+                                                record.getValueByKey("time") != null ?
+                                                        Long.parseLong(Objects.requireNonNull(record.getValueByKey("time")).toString()) : null);
+                                        dataPoint.addTag("aircraft_id", (String) record.getValueByKey("aircraft_id"));
+                                        dataPoint.addTag("sortie_number", (String) record.getValueByKey("sortie_number"));
+                                        dataPoint.addField("message_date_time", record.getValueByKey("message_date_time"));
+                                        dataPoint.addField("interception_status", record.getValueByKey("interception_status"));
+                                        dataPoint.addField("latitude", Double.parseDouble(Objects.requireNonNull(record.getValueByKey("latitude")).toString()));
+                                        dataPoints.add(dataPoint);
+                                    }
+                                }
+                            }
+                            return dataPoints;
+                        }
+                )
+                // 设置数据点的反序列化器 即最终的输出 将 datapoint 转换为您需要的对象类型
+                .setDataPointDeserializer(new InfluxDBDataPointDeserializer<String>() {
+                    @Override
+                    public String deserialize(DataPoint dataPoint) throws IOException {
+                        log.info("dataPoint fetched.");
+                        // 真的要转换成对象的时候就在这里用dataPoint.getTag dataPoint.getField就可以
+                        return dataPoint.toString();
+                    }
+                })
+                .build();
+
+        env.fromSource(influxDBSource, WatermarkStrategy.noWatermarks(), "InfluxDB Source")
+                .print();
+
+        env.execute();
+    }
+
+    private static Long convertInstantToNs(Instant instant) throws IOException {
+        if (instant == null) {
+            throw new IOException("Instant cannot be null");
+        }
+        return instant.getEpochSecond() * 1_000_000_000 + instant.getNano();
+    }
+
+    private static Instant convertNsToInstant(Long ns) throws IOException {
+        if (ns == null) {
+            throw new IOException("Nanoseconds cannot be null");
+        }
+        long seconds = ns / 1_000_000_000;
+        int nanos = (int) (ns % 1_000_000_000);
+        return Instant.ofEpochSecond(seconds, nanos);
+    }
+}

--- a/flink-connector-influxdb2/src/test/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceIntegrationTestCase.java
+++ b/flink-connector-influxdb2/src/test/java/org/apache/flink/streaming/connectors/influxdb/source/InfluxDBSourceIntegrationTestCase.java
@@ -87,8 +87,7 @@ class InfluxDBSourceIntegrationTestCase extends TestLogger {
     void testIncrementPipeline() throws Exception {
         final InfluxDBSource<Long> influxDBSource =
                 InfluxDBSource.builder()
-                        .setPort(this.port)
-                        .setDeserializer(new InfluxDBTestDeserializer())
+                        .setDataPointDeserializer(new InfluxDBTestDeserializer())
                         .build();
 
         this.env
@@ -116,8 +115,7 @@ class InfluxDBSourceIntegrationTestCase extends TestLogger {
     void testBadRequestException() throws Exception {
         final InfluxDBSource<Long> influxDBSource =
                 InfluxDBSource.builder()
-                        .setPort(this.port)
-                        .setDeserializer(new InfluxDBTestDeserializer())
+                        .setDataPointDeserializer(new InfluxDBTestDeserializer())
                         .build();
 
         this.env
@@ -139,9 +137,7 @@ class InfluxDBSourceIntegrationTestCase extends TestLogger {
     void testRequestTooLargeException() throws Exception {
         final InfluxDBSource<Long> influxDBSource =
                 InfluxDBSource.builder()
-                        .setPort(this.port)
-                        .setDeserializer(new InfluxDBTestDeserializer())
-                        .setMaximumLinesPerRequest(2)
+                        .setDataPointDeserializer(new InfluxDBTestDeserializer())
                         .build();
         this.env
                 .fromSource(influxDBSource, WatermarkStrategy.noWatermarks(), "InfluxDBSource")

--- a/flink-connector-influxdb2/src/test/resources/log4j2-test.properties
+++ b/flink-connector-influxdb2/src/test/resources/log4j2-test.properties
@@ -17,24 +17,24 @@
 #
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-status=warn
+status=debug
 appender.console.type=Console
 appender.console.name=LogToConsole
 appender.console.layout.type=PatternLayout
 appender.console.layout.pattern=%d{HH:mm:ss.SSS} - %highlight{%5p} %style{%logger{36}}{cyan} - %m%n%throwable
 ### Logger test containers ###
 logger.testContainers.name=org.testcontainers
-logger.testContainers.level=WARN
+logger.testContainers.level=debug
 logger.testContainers.additivity=false
 logger.testContainers.appenderRef.console.ref=LogToConsole
 ### Logger Docker Java ###
 logger.dockerJava.name=com.github.dockerjava
-logger.dockerJava.level=WARN
+logger.dockerJava.level=debug
 logger.dockerJava.additivity=false
 logger.dockerJava.appenderRef.console.ref=LogToConsole
 ### Logger Apache Flink ###
 logger.apacheFlink.name=org.apache.flink
-logger.apacheFlink.level=WARN
+logger.apacheFlink.level=debug
 logger.apacheFlink.additivity=false
 logger.apacheFlink.appenderRef.console.ref=LogToConsole
 ### Logger Apache Streaming Connectors ###
@@ -43,4 +43,4 @@ logger.streamingConnectors.level=INFO
 logger.streamingConnectors.additivity=false
 logger.streamingConnectors.appenderRef.console.ref=LogToConsole
 # Root Logger
-rootLogger.level=OFF
+rootLogger.level=INFO

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <module>flink-connector-flume</module>
         <module>flink-connector-influxdb</module>
         <module>flink-connector-influxdb2</module>
-        <module>flink-connector-kudu</module>
+<!--        <module>flink-connector-kudu</module>-->
         <module>flink-connector-netty</module>
         <module>flink-connector-pinot</module>
         <module>flink-connector-redis</module>
@@ -124,7 +124,7 @@
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
         <!-- Flink version -->
-        <flink.version>1.17.0</flink.version>
+        <flink.version>1.20.0</flink.version>
         <scala.binary.version>2.12</scala.binary.version>
         <scala.version>2.12.18</scala.version>
 


### PR DESCRIPTION
+ flink-connector-influxdb2 现已适配 Flink 1.20.0 LTS
+ Source 侧仿照 flink-connector-jdbc 完全重写，剥离原有 Telegraf 逻辑，实现基于时间分片从 InfluxDB 拉取数据，支持标准 Source 语义
+ Sink 侧修复部分逻辑，添加定时 flush 功能
+ 新增用户文档说明与代码示例（InfluxDBSourceDemo.java）
+ 完善配置项和序列化，提升可维护性